### PR TITLE
chat query fix - added enabled tag

### DIFF
--- a/src/hooks/reactQuery/useRag.ts
+++ b/src/hooks/reactQuery/useRag.ts
@@ -74,6 +74,7 @@ export const useGetAgentChatHistory = (agentId: string | undefined) => {
       return result;
     },
     staleTime: ONE_HOUR_STALE_TIME,
+    enabled: !!wallet?.principalId,
   });
 };
 


### PR DESCRIPTION
issue was with users not being logged in
AgentChatHistory kept invalidating responses when logged out, 
added enabled tag to have it run only when logged in, tested, works fine

Only caveat is that currently we check for history when chat page opens so if a not logged in user navigates away from chat page, history is lost, 